### PR TITLE
Add process priority management and interactive UI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Build with dotnet
         run: dotnet build --configuration Release
@@ -33,7 +33,7 @@ jobs:
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '9.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Publish with dotnet
         run: dotnet publish --configuration Release
@@ -42,7 +42,7 @@ jobs:
       - name: Archive Release
         uses: montudor/action-zip@v1.0.0
         with:
-          args: zip -jr StartupManager ./src/StartupManager/bin/Release/net9.0/win-x64/publish/StartupManager.exe
+          args: zip -jr StartupManager ./src/StartupManager/bin/Release/net10.0/win-x64/publish/StartupManager.exe
 
       - name: Release
         uses: anton-yurchenko/git-release@v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated to .NET 10
+- Changed set-priority command alias from "sp" to "p" for consistency with other single-letter aliases
+
+### Added
+
+- Added priority support for startup programs (ProcessPriority property)
+
 ## [1.6.3] - 2025-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ I recommend installing through scoop to have the app accessible on your "path"
 
 ## Commands
 
-There are currently four functional commands `list`, `enable`, `disable`, `add`
+There are currently six functional commands `list`, `enable`, `disable`, `add`, `remove`, `set-priority`
 
 ### Help
 
@@ -49,6 +49,7 @@ Commands:
   e, enable <name>                    Enables one of the current startup programs
   a, add <name> <path> <arguments>    Adds a program to startup with windows
   r, remove <name>                    Removes the specified program from startup
+  p, set-priority <name> <priority>  Sets the priority of a Task Scheduler startup program
 ```
 
 The help command can also be used on any commands;
@@ -204,3 +205,19 @@ It's possible to skip the confirmation by adding the option `--confirm` or `-c`
 ```text
 MyWelcomeApp has been removed
 ```
+
+### Set-Priority
+
+This command allows you to set the priority level for Task Scheduler startup programs. The priority levels available are: Idle, BelowNormal, Normal, AboveNormal, High, or Realtime.
+
+Examples of usage
+
+`StartupManager set-priority MyWelcomeApp Normal` or `StartupManager p MyWelcomeApp Normal` would output
+
+```text
+Priority for MyWelcomeApp has been set to Normal
+```
+
+You can also use the index from the list command:
+
+`StartupManager p 1 High` would set the priority of the program at index 1 to High.

--- a/src/StartupManager.Models/Enums.cs
+++ b/src/StartupManager.Models/Enums.cs
@@ -4,4 +4,13 @@ namespace StartupManager.Models {
         SameState,
         Unauthorized
     }
+
+    public enum ProcessPriority {
+        Idle = 0,
+        BelowNormal = 1,
+        Normal = 2,
+        AboveNormal = 3,
+        High = 4,
+        Realtime = 5
+    }
 }

--- a/src/StartupManager.Models/StartupList.cs
+++ b/src/StartupManager.Models/StartupList.cs
@@ -13,6 +13,7 @@ namespace StartupManager.Models {
         public string RegistryName { get; set; }
         public StartupType Type { get; set; }
         public int Index { get; set; }
+        public ProcessPriority? Priority { get; set; }
 
         public StartupList(string name, [AllowNull] string path, bool requireAdministrator, bool disabled, StartupType type, bool allUsers, string registryPath, string disabledRegistryPath, string registryName) {
             Path = path ?? string.Empty;
@@ -25,6 +26,7 @@ namespace StartupManager.Models {
             RegistryPath = registryPath;
             DisabledRegistryPath = disabledRegistryPath;
             RegistryName = registryName;
+            Priority = null;
         }
 
         public StartupList(string name, [AllowNull] string path, bool requireAdministrator, bool disabled, StartupType type, bool allUsers) {
@@ -38,6 +40,21 @@ namespace StartupManager.Models {
             RegistryPath = string.Empty;
             DisabledRegistryPath = string.Empty;
             RegistryName = string.Empty;
+            Priority = null;
+        }
+
+        public StartupList(string name, [AllowNull] string path, bool requireAdministrator, bool disabled, StartupType type, bool allUsers, ProcessPriority? priority) {
+            Path = path ?? string.Empty;
+            RequireAdministrator = requireAdministrator;
+            Disabled = disabled;
+            Type = type;
+            AllUsers = allUsers;
+            Name = name;
+
+            RegistryPath = string.Empty;
+            DisabledRegistryPath = string.Empty;
+            RegistryName = string.Empty;
+            Priority = priority;
         }
 
         private string ParseName(string name) {

--- a/src/StartupManager.Models/StartupProgram.cs
+++ b/src/StartupManager.Models/StartupProgram.cs
@@ -16,6 +16,7 @@ namespace StartupManager.Models {
             this.AllUsers = allUsers;
             this.Priority = ProcessPriority.Normal;
         }
+
         public StartupProgram(string name, FileInfo file, string arguments, bool administrator, bool allUsers, ProcessPriority priority) {
             this.Name = name;
             this.File = file;

--- a/src/StartupManager.Models/StartupProgram.cs
+++ b/src/StartupManager.Models/StartupProgram.cs
@@ -7,12 +7,22 @@ namespace StartupManager.Models {
         public string Arguments { get; set; }
         public bool Administrator { get; set; }
         public bool AllUsers { get; set; }
+        public ProcessPriority Priority { get; set; }
         public StartupProgram(string name, FileInfo file, string arguments, bool administrator, bool allUsers) {
             this.Name = name;
             this.File = file;
             this.Arguments = arguments;
             this.Administrator = administrator;
             this.AllUsers = allUsers;
+            this.Priority = ProcessPriority.Normal;
+        }
+        public StartupProgram(string name, FileInfo file, string arguments, bool administrator, bool allUsers, ProcessPriority priority) {
+            this.Name = name;
+            this.File = file;
+            this.Arguments = arguments;
+            this.Administrator = administrator;
+            this.AllUsers = allUsers;
+            this.Priority = priority;
         }
     }
 }

--- a/src/StartupManager.Services/Schedulers/ITaskSchedulerService.cs
+++ b/src/StartupManager.Services/Schedulers/ITaskSchedulerService.cs
@@ -11,5 +11,6 @@ namespace StartupManager.Services.Schedulers {
         StartupList? GetStartupByName(string name);
         StartupList? GetStartupByPredicate(Func<Task, bool> predicate);
         StateChange ToggleStartupState(StartupList program, bool enable);
+        StateChange SetPriority(StartupList program, ProcessPriority priority);
     }
 }

--- a/src/StartupManager/Commands/CommandBuilder.cs
+++ b/src/StartupManager/Commands/CommandBuilder.cs
@@ -104,7 +104,7 @@ namespace StartupManager.Commands {
                 Description = "Sets the priority of a Task Scheduler startup program"
             };
 
-            setPriorityCommand.AddAlias("sp");
+            setPriorityCommand.AddAlias("p");
 
             setPriorityCommand.AddArgument(new Argument<string>("name", description: "Name or index of the program to set priority for"));
             setPriorityCommand.AddArgument(new Argument<string>("priority", description: "Priority level: Idle, BelowNormal, Normal, AboveNormal, High, or Realtime"));

--- a/src/StartupManager/Commands/CommandBuilder.cs
+++ b/src/StartupManager/Commands/CommandBuilder.cs
@@ -3,6 +3,7 @@ using System.CommandLine.Invocation;
 using System.IO;
 using StartupManager.Commands.Add;
 using StartupManager.Commands.Remove;
+using StartupManager.Commands.SetPriority;
 using StartupManager.Commands.StartupList;
 using StartupManager.Commands.StartupToggle;
 
@@ -13,7 +14,8 @@ namespace StartupManager.Commands {
             GetDisableStartupCommand(),
             GetEnableStartupCommand(),
             GetAddStartupCommand(),
-            GetRemoveStartupCommand()
+            GetRemoveStartupCommand(),
+            GetSetPriorityCommand()
         };
 
         private static Command GetStartupListCommand() {
@@ -44,8 +46,9 @@ namespace StartupManager.Commands {
             addCommand.AddArgument(new Argument<string?>("arguments", null) { Arity = ArgumentArity.ZeroOrOne });
             addCommand.AddArgument(new Argument<bool?>("admin", null) { Arity = ArgumentArity.ZeroOrOne });
             addCommand.AddArgument(new Argument<bool?>("allUsers", null) { Arity = ArgumentArity.ZeroOrOne });
+            addCommand.AddArgument(new Argument<string?>("priority", null) { Arity = ArgumentArity.ZeroOrOne });
 
-            addCommand.Handler = CommandHandler.Create<string?, FileInfo?, string?, bool?, bool?>(AddCommand.Run);
+            addCommand.Handler = CommandHandler.Create<string?, FileInfo?, string?, bool?, bool?, string?>(AddCommand.Run);
 
             return addCommand;
         }
@@ -94,6 +97,21 @@ namespace StartupManager.Commands {
             enableCommand.Handler = CommandHandler.Create<string>(EnableCommand.Run);
 
             return enableCommand;
+        }
+
+        private static Command GetSetPriorityCommand() {
+            var setPriorityCommand = new Command("set-priority") {
+                Description = "Sets the priority of a Task Scheduler startup program"
+            };
+
+            setPriorityCommand.AddAlias("sp");
+
+            setPriorityCommand.AddArgument(new Argument<string>("name", description: "Name or index of the program to set priority for"));
+            setPriorityCommand.AddArgument(new Argument<string>("priority", description: "Priority level: Idle, BelowNormal, Normal, AboveNormal, High, or Realtime"));
+
+            setPriorityCommand.Handler = CommandHandler.Create<string, string>(SetPriorityCommand.Run);
+
+            return setPriorityCommand;
         }
     }
 }

--- a/src/StartupManager/Commands/SetPriority/SetPriorityCommand.cs
+++ b/src/StartupManager/Commands/SetPriority/SetPriorityCommand.cs
@@ -1,0 +1,11 @@
+using StartupManager.ConsoleOutputters;
+
+namespace StartupManager.Commands.SetPriority {
+    public static class SetPriorityCommand {
+        public static void Run(string name, string priority) {
+            var messages = SetPriorityCommandHandler.Run(name, priority);
+            ConsoleOutputWriter.WriteToConsole(messages);
+        }
+    }
+}
+

--- a/src/StartupManager/Commands/SetPriority/SetPriorityCommandHandler.cs
+++ b/src/StartupManager/Commands/SetPriority/SetPriorityCommandHandler.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using StartupManager.Models;
+using StartupManager.Services.Registries;
+using StartupManager.Services.Schedulers;
+using StartupManager.Services.Startup;
+
+namespace StartupManager.Commands.SetPriority {
+    public static class SetPriorityCommandHandler {
+        private static ITaskSchedulerService TaskSchedulerService = new TaskSchedulerService();
+        private static IStartupQueryService StartupQueryService = new StartupQueryService();
+        private static IRegistryService RegistryService = new RegistryService();
+
+        public static IEnumerable<ConsoleColorOutput> Run(string name, string priority) {
+            var consoleMessages = new List<ConsoleColorOutput>();
+
+            if (!Enum.TryParse<ProcessPriority>(priority, true, out var priorityValue)) {
+                return new[] {
+                    new ConsoleColorOutput(WriteMode.Write, "Invalid priority: ", ConsoleColor.Red),
+                    new ConsoleColorOutput(WriteMode.Writeline, priority, ConsoleColor.Yellow),
+                    new ConsoleColorOutput(WriteMode.Writeline, "Valid priorities are: Idle, BelowNormal, Normal, AboveNormal, High, Realtime", ConsoleColor.Red)
+                };
+            }
+
+            var startupStates = RegistryService.GetStartupProgramStates();
+            Models.StartupList? program = null;
+            if (int.TryParse(name, out int index)) {
+                program = StartupQueryService.GetStartupByIndex(index);
+            }
+            program ??= StartupQueryService.GetStartupByName(name, startupStates);
+
+            if (program == null) {
+                return WriteProgramNotFoundConsoleOutput(name);
+            }
+
+            if (program.Type != Models.StartupList.StartupType.TaskScheduler) {
+                return new[] {
+                    new ConsoleColorOutput(WriteMode.Write, "Priority can only be set for Task Scheduler startup programs. ", ConsoleColor.Red),
+                    new ConsoleColorOutput(WriteMode.Write, program.Name, ConsoleColor.Yellow),
+                    new ConsoleColorOutput(WriteMode.Writeline, $" is a {program.Type} startup program.", ConsoleColor.Red)
+                };
+            }
+
+            var result = TaskSchedulerService.SetPriority(program, priorityValue);
+            switch (result) {
+                case StateChange.SameState:
+                    return WriteSamePriorityConsoleOutput(program, priorityValue);
+                case StateChange.Success:
+                    return WritePrioritySetConsoleOutput(program, priorityValue);
+                case StateChange.Unauthorized:
+                    return WriteRequireAdministratorConsoleOutput(program);
+            }
+            return new List<ConsoleColorOutput>();
+        }
+
+        private static IEnumerable<ConsoleColorOutput> WriteProgramNotFoundConsoleOutput(string name) {
+            return new[] {
+                new ConsoleColorOutput(WriteMode.Write, "Could not find a program with name/index ", ConsoleColor.Red),
+                new ConsoleColorOutput(WriteMode.Writeline, name, ConsoleColor.Yellow),
+            };
+        }
+
+        private static IEnumerable<ConsoleColorOutput> WriteSamePriorityConsoleOutput(Models.StartupList program, ProcessPriority priority) {
+            return new[] {
+                new ConsoleColorOutput(WriteMode.Write, program.Name, ConsoleColor.Yellow),
+                new ConsoleColorOutput(WriteMode.Writeline, $" already has priority set to {priority}"),
+            };
+        }
+
+        private static IEnumerable<ConsoleColorOutput> WriteRequireAdministratorConsoleOutput(Models.StartupList program) {
+            return new[] {
+                new ConsoleColorOutput(WriteMode.Write, $"To modify priority for ", ConsoleColor.Red),
+                new ConsoleColorOutput(WriteMode.Write, program.Name, ConsoleColor.Yellow),
+                new ConsoleColorOutput(WriteMode.Writeline, " you need to run the command with administrator (sudo)", ConsoleColor.Red),
+            };
+        }
+
+        private static IEnumerable<ConsoleColorOutput> WritePrioritySetConsoleOutput(Models.StartupList program, ProcessPriority priority) {
+            return new[] {
+                new ConsoleColorOutput(WriteMode.Write, program.Name, ConsoleColor.Yellow),
+                new ConsoleColorOutput(WriteMode.Writeline, $" priority has been set to {priority}"),
+            };
+        }
+    }
+}
+

--- a/src/StartupManager/ConsoleOutputters/ListOutput/ListCommandOutputter.cs
+++ b/src/StartupManager/ConsoleOutputters/ListOutput/ListCommandOutputter.cs
@@ -17,6 +17,7 @@ namespace StartupManager.ConsoleOutputters.ListOutput {
                 new Header<StartupList>("Name", x => x.Name, x => ConsoleColor.Yellow),
                 new Header<StartupList>("Admin", x => x.RequireAdministrator ? "[\u221A]" : string.Empty, x => ConsoleColor.Cyan),
                 new Header<StartupList>("Enabled", x => x.Disabled ? "[x]" : "[\u221A]", x => x.Disabled ? ConsoleColor.Red : ConsoleColor.DarkCyan),
+                new Header<StartupList>("Priority", x => x.Priority?.ToString() ?? "N/A", x => x.Priority.HasValue ? ConsoleColor.Magenta : ConsoleColor.DarkGray),
             };
 
             if (detailed) {

--- a/src/StartupManager/Program.cs
+++ b/src/StartupManager/Program.cs
@@ -1,10 +1,17 @@
-﻿using System.CommandLine;
+using System.CommandLine;
 using System.Threading.Tasks;
 using StartupManager.Commands;
+using StartupManager.UI;
 
 namespace StartupManager {
     class Program {
         async static Task<int> Main(string[] args) {
+            // Show interactive UI if no arguments provided
+            if (args == null || args.Length == 0) {
+                InteractiveMenu.Show();
+                return 0;
+            }
+
             var rootCommand = CommandBuilder.GetRootCommand();
             return await rootCommand.InvokeAsync(args);
         }

--- a/src/StartupManager/StartupManager.csproj
+++ b/src/StartupManager/StartupManager.csproj
@@ -2,12 +2,13 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier> 
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
     <Version>1.6.3</Version>
     <Nullable>enable</Nullable>
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/StartupManager/UI/InteractiveMenu.cs
+++ b/src/StartupManager/UI/InteractiveMenu.cs
@@ -1,0 +1,175 @@
+using System;
+using System.Linq;
+using StartupManager.Commands.Add;
+using StartupManager.Commands.Remove;
+using StartupManager.Commands.SetPriority;
+using StartupManager.Commands.StartupList;
+using StartupManager.Commands.StartupToggle;
+using StartupManager.ConsoleOutputters;
+
+namespace StartupManager.UI {
+    public static class InteractiveMenu {
+        public static void Show() {
+            while (true) {
+                Console.Clear();
+                ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Cyan, 
+                    "╔════════════════════════════════════════════════════════════╗",
+                    "║           Startup Manager - Interactive Menu              ║",
+                    "╚════════════════════════════════════════════════════════════╝",
+                    ""
+                );
+
+                // Display the startup list
+                ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Yellow, "Current Startup Programs:");
+                Console.WriteLine();
+                ListCommand.Run(false);
+                Console.WriteLine();
+
+                // Display menu options
+                ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Green, "Menu Options:");
+                Console.WriteLine("  1. Add a new startup program");
+                Console.WriteLine("  2. Remove a startup program");
+                Console.WriteLine("  3. Enable a startup program");
+                Console.WriteLine("  4. Disable a startup program");
+                Console.WriteLine("  5. Set priority for a startup program");
+                Console.WriteLine("  6. Refresh list");
+                Console.WriteLine("  7. Show detailed list");
+                Console.WriteLine("  0. Exit");
+                Console.WriteLine();
+
+                ConsoleColorHelper.ConsoleWriteColored(ConsoleColor.Cyan, "Enter your choice: ");
+                var choice = Console.ReadLine()?.Trim();
+
+                if (string.IsNullOrEmpty(choice)) {
+                    continue;
+                }
+
+                switch (choice) {
+                    case "1":
+                        HandleAdd();
+                        break;
+                    case "2":
+                        HandleRemove();
+                        break;
+                    case "3":
+                        HandleEnable();
+                        break;
+                    case "4":
+                        HandleDisable();
+                        break;
+                    case "5":
+                        HandleSetPriority();
+                        break;
+                    case "6":
+                        // Just refresh by continuing the loop
+                        break;
+                    case "7":
+                        HandleDetailedList();
+                        break;
+                    case "0":
+                        ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Green, "Goodbye!");
+                        return;
+                    default:
+                        ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Red, "Invalid choice. Please try again.");
+                        Console.WriteLine("Press any key to continue...");
+                        Console.ReadKey();
+                        break;
+                }
+            }
+        }
+
+        private static void HandleAdd() {
+            Console.Clear();
+            ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Cyan, "Add New Startup Program");
+            Console.WriteLine();
+            AddCommand.Run(null, null, null, null, null, null);
+            Console.WriteLine();
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadKey();
+        }
+
+        private static void HandleRemove() {
+            Console.Clear();
+            ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Cyan, "Remove Startup Program");
+            Console.WriteLine();
+            ConsoleColorHelper.ConsoleWriteColored(ConsoleColor.Yellow, "Enter the name or index of the program to remove: ");
+            var name = Console.ReadLine()?.Trim();
+            if (!string.IsNullOrEmpty(name)) {
+                RemoveCommand.Run(name, true);
+            } else {
+                ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Red, "Name or index cannot be empty.");
+            }
+            Console.WriteLine();
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadKey();
+        }
+
+        private static void HandleEnable() {
+            Console.Clear();
+            ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Cyan, "Enable Startup Program");
+            Console.WriteLine();
+            ConsoleColorHelper.ConsoleWriteColored(ConsoleColor.Yellow, "Enter the name or index of the program to enable: ");
+            var name = Console.ReadLine()?.Trim();
+            if (!string.IsNullOrEmpty(name)) {
+                EnableCommand.Run(name);
+            } else {
+                ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Red, "Name or index cannot be empty.");
+            }
+            Console.WriteLine();
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadKey();
+        }
+
+        private static void HandleDisable() {
+            Console.Clear();
+            ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Cyan, "Disable Startup Program");
+            Console.WriteLine();
+            ConsoleColorHelper.ConsoleWriteColored(ConsoleColor.Yellow, "Enter the name or index of the program to disable: ");
+            var name = Console.ReadLine()?.Trim();
+            if (!string.IsNullOrEmpty(name)) {
+                DisableCommand.Run(name);
+            } else {
+                ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Red, "Name or index cannot be empty.");
+            }
+            Console.WriteLine();
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadKey();
+        }
+
+        private static void HandleSetPriority() {
+            Console.Clear();
+            ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Cyan, "Set Priority for Startup Program");
+            Console.WriteLine();
+            ConsoleColorHelper.ConsoleWriteColored(ConsoleColor.Yellow, "Enter the name or index of the program: ");
+            var name = Console.ReadLine()?.Trim();
+            if (string.IsNullOrEmpty(name)) {
+                ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Red, "Name or index cannot be empty.");
+                Console.WriteLine();
+                Console.WriteLine("Press any key to continue...");
+                Console.ReadKey();
+                return;
+            }
+
+            ConsoleColorHelper.ConsoleWriteColored(ConsoleColor.Yellow, "Enter priority (Idle, BelowNormal, Normal, AboveNormal, High, Realtime): ");
+            var priority = Console.ReadLine()?.Trim();
+            if (!string.IsNullOrEmpty(priority)) {
+                SetPriorityCommand.Run(name, priority);
+            } else {
+                ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Red, "Priority cannot be empty.");
+            }
+            Console.WriteLine();
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadKey();
+        }
+
+        private static void HandleDetailedList() {
+            Console.Clear();
+            ConsoleColorHelper.ConsoleWriteLineColored(ConsoleColor.Cyan, "Detailed Startup Programs List");
+            Console.WriteLine();
+            ListCommand.Run(true);
+            Console.WriteLine();
+            Console.WriteLine("Press any key to continue...");
+            Console.ReadKey();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds process priority management for Task Scheduler startup programs and implements an interactive menu UI for easier program management.

## Changes
- **Priority feature**: New `set-priority` command (alias: `sp`) to set process priority (Idle, BelowNormal, Normal, AboveNormal, High, Realtime) for Task Scheduler programs
- **Priority in add command**: Users can specify priority when adding new startup programs
- **Interactive menu UI**: New interactive menu that displays when running without arguments, providing easy access to all operations including priority management
- **Priority display**: Priority information shown in startup programs list

## Technical Details
- Priority managed through Task Scheduler service
- Interactive menu supports all operations: add, remove, enable/disable, set priority, and list viewing
- Maintains full CLI backward compatibility